### PR TITLE
Add wasCreatedFromSchedule boolean field to Data Exports API response

### DIFF
--- a/spec/definitions/Export.yaml
+++ b/spec/definitions/Export.yaml
@@ -70,6 +70,10 @@ properties:
     description: The number of records in the export
     readOnly: true
     type: integer
+  wasCreatedFromSchedule:
+    description: Indicates whether or not this export was created via scheduled export request
+    readOnly: true
+    type: boolean
   createdTime:
     description: Export request created time
     allOf:


### PR DESCRIPTION
Add a boolean field called `wasCreatedFromSchedule` to the Data Exports API response structure. This will let the user know if this export was created from a scheduled export as opposed to the traditional manual way.