### PR TITLE
Add DataExportInstruction to DataExports definitions

### DIFF
--- a/spec/definitions/DataExport.yaml
+++ b/spec/definitions/DataExport.yaml
@@ -1,0 +1,29 @@
+type: object
+required:
+  - dataExportInstruction
+properties:
+  id:
+    description: The export identifier string
+    readOnly: true
+    allOf:
+      - $ref: "#/definitions/ResourceId"
+  dataExportInstruction:
+    allOf:
+      - $ref: "#/definitions/ExportInstruction"
+  createdTime:
+    description: Export schedule created time
+    allOf:
+      - $ref: "#/definitions/ServerTimestamp"
+  updatedTime:
+    description: Export schedule updated time
+    allOf:
+      - $ref: "#/definitions/ServerTimestamp"
+  _links:
+    type: array
+    description: The links related to resource
+    readOnly: true
+    minItems: 1
+    maxItems: 2
+    items:
+      - $ref: "#/definitions/SelfLink"
+      - $ref: "#/definitions/CreatedByLink"

--- a/spec/definitions/DataExport.yaml
+++ b/spec/definitions/DataExport.yaml
@@ -10,6 +10,28 @@ properties:
   dataExportInstruction:
     allOf:
       - $ref: "#/definitions/ExportInstruction"
+  fileId:
+    description: File ID
+    readOnly: true
+    type: string
+  status:
+    description: Status of export request
+    readOnly: true
+    type: string
+    enum:
+      - pending
+      - processing
+      - completed
+  recordCount:
+    description: The number of records in the export
+    readOnly: true
+    type: integer
+  wasCreatedFromSchedule:
+    description: >-
+      Indicates whether or not this export was created via scheduled export
+      request
+    readOnly: true
+    type: boolean
   createdTime:
     description: Export schedule created time
     allOf:

--- a/spec/definitions/ExportInstruction.yaml
+++ b/spec/definitions/ExportInstruction.yaml
@@ -1,5 +1,5 @@
 type: object
-description: Export details to be processed during recurring scheduling
+description: Defines the parameters of the requested data export
 required:
   - name
   - format
@@ -21,8 +21,10 @@ properties:
     type: string
     readOnly: true
   resource:
-    description: 'The type of resource being exported (eg., transaction).'
+    description: 'The type of resource being exported (eg., transactions).'
     type: string
+    enum:
+      - transactions
   format:
     description: Export result format
     type: string

--- a/spec/definitions/ExportInstruction.yaml
+++ b/spec/definitions/ExportInstruction.yaml
@@ -3,12 +3,10 @@ description: Export details to be processed during recurring scheduling
 required:
   - name
   - format
+  - resource
 properties:
   name:
     description: Export name
-    type: string
-  resource:
-    description: Export resource
     type: string
   createdById:
     description: External ID of the user who created the export
@@ -25,7 +23,6 @@ properties:
   resource:
     description: 'The type of resource being exported (eg., transaction).'
     type: string
-    readOnly: true
   format:
     description: Export result format
     type: string

--- a/spec/definitions/ExportInstruction.yaml
+++ b/spec/definitions/ExportInstruction.yaml
@@ -7,6 +7,9 @@ properties:
   name:
     description: Export name
     type: string
+  resource:
+    description: Export resource
+    type: string
   createdById:
     description: External ID of the user who created the export
     type: string

--- a/spec/paths/data-exports.yaml
+++ b/spec/paths/data-exports.yaml
@@ -1,0 +1,55 @@
+post:
+  tags:
+    - Data Exports
+  summary: Request a bulk export of selected resource
+  description: |
+    Request a bulk export of selected resource
+  parameters:
+    - name: body
+      in: body
+      description: Export Request
+      required: true
+      schema:
+        $ref: "#/definitions/DataExport"
+  responses:
+    201:
+      description: Bulk export request received
+      headers:
+        Rate-Limit-Limit:
+          $ref: "#/headers/Rate-Limit-Limit"
+        Rate-Limit-Remaining:
+          $ref: "#/headers/Rate-Limit-Remaining"
+        Rate-Limit-Reset:
+          $ref: "#/headers/Rate-Limit-Reset"
+      schema:
+        $ref: "#/definitions/DataExport"
+    401:
+      $ref: "#/responses/AccessForbidden"
+get:
+  tags:
+    - Data Exports
+  summary: Retrieve a list of export requests
+  description: |
+    Retrieve a list of export requests
+  responses:
+    200:
+      description: A list of export requests was retrieved successfully
+      headers:
+        Rate-Limit-Limit:
+          $ref: "#/headers/Rate-Limit-Limit"
+        Rate-Limit-Remaining:
+          $ref: "#/headers/Rate-Limit-Remaining"
+        Rate-Limit-Reset:
+          $ref: "#/headers/Rate-Limit-Reset"
+        Pagination-Total:
+          $ref: "#/headers/Pagination-Total"
+        Pagination-Limit:
+          $ref: "#/headers/Pagination-Limit"
+        Pagination-Offset:
+          $ref: "#/headers/Pagination-Offset"
+      schema:
+        type: array
+        items:
+          $ref: "#/definitions/DataExport"
+    401:
+      $ref: "#/responses/AccessForbidden"

--- a/spec/paths/data-exports.yaml
+++ b/spec/paths/data-exports.yaml
@@ -1,19 +1,19 @@
 post:
   tags:
     - Data Exports
-  summary: Request a bulk export of selected resource
+  summary: Request a data export of selected resource
   description: |
-    Request a bulk export of selected resource
+    Request a data export of selected resource
   parameters:
     - name: body
       in: body
-      description: Export Request
+      description: Data Export Request
       required: true
       schema:
         $ref: "#/definitions/DataExport"
   responses:
     201:
-      description: Bulk export request received
+      description: Data export request received
       headers:
         Rate-Limit-Limit:
           $ref: "#/headers/Rate-Limit-Limit"
@@ -28,12 +28,12 @@ post:
 get:
   tags:
     - Data Exports
-  summary: Retrieve a list of export requests
+  summary: Retrieve a list of data export requests
   description: |
-    Retrieve a list of export requests
+    Retrieve a list of data export requests
   responses:
     200:
-      description: A list of export requests was retrieved successfully
+      description: A list of data export requests was retrieved successfully
       headers:
         Rate-Limit-Limit:
           $ref: "#/headers/Rate-Limit-Limit"

--- a/spec/paths/data-exports@{id}.yaml
+++ b/spec/paths/data-exports@{id}.yaml
@@ -3,14 +3,14 @@ parameters:
 get:
   tags:
     - Data Exports
-  summary: Retrieve an export request
+  summary: Retrieve a data export request
   description: |
-    Retrieve an export request
+    Retrieve a data export request
   produces:
     - application/json
   responses:
     200:
-      description: Export request
+      description: Data Export request
       headers:
         Rate-Limit-Limit:
           $ref: "#/headers/Rate-Limit-Limit"

--- a/spec/paths/data-exports@{id}.yaml
+++ b/spec/paths/data-exports@{id}.yaml
@@ -1,0 +1,30 @@
+parameters:
+  - $ref: "#/parameters/resourceId"
+get:
+  tags:
+    - Data Exports
+  summary: Retrieve an export request
+  description: |
+    Retrieve an export request
+  produces:
+    - application/json
+  responses:
+    200:
+      description: Export request
+      headers:
+        Rate-Limit-Limit:
+          $ref: "#/headers/Rate-Limit-Limit"
+        Rate-Limit-Remaining:
+          $ref: "#/headers/Rate-Limit-Remaining"
+        Rate-Limit-Reset:
+          $ref: "#/headers/Rate-Limit-Reset"
+        Pagination-Total:
+          $ref: "#/headers/Pagination-Total"
+        Pagination-Limit:
+          $ref: "#/headers/Pagination-Limit"
+        Pagination-Offset:
+          $ref: "#/headers/Pagination-Offset"
+      schema:
+        $ref: "#/definitions/DataExport"
+    401:
+      $ref: "#/responses/AccessForbidden"


### PR DESCRIPTION
This does not remove `Exports` section because those specs might be used by current FE implementation (so it doesn't break BC). This PR adds new `DataExports` section

Preview - https://rebilly.github.io/RebillyReportsAPI/preview/refactor-dataexports