### PR TITLE
Remove Export (without Data) tags

### DIFF
--- a/spec/paths/export-schedules@transactions.yaml
+++ b/spec/paths/export-schedules@transactions.yaml
@@ -1,6 +1,6 @@
 post:
   tags:
-    - Export Schedules
+    - Data Export Schedules
   summary: Schedule recurring exports
   description: |
     Schedule recurring exports
@@ -27,7 +27,7 @@ post:
       $ref: "#/responses/AccessForbidden"
 get:
   tags:
-    - Export Schedules
+    - Data Export Schedules
   summary: Retrieve a list of export schedules
   description: |
     Retrieve a list of export schedules

--- a/spec/paths/export-schedules@transactions@{id}.yaml
+++ b/spec/paths/export-schedules@transactions@{id}.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: "#/parameters/resourceId"
 get:
   tags:
-    - Export Schedules
+    - Data Export Schedules
   summary: Retrieve an export schedule
   description: |
     Retrieve an export schedule
@@ -30,7 +30,7 @@ get:
       $ref: "#/responses/AccessForbidden"
 put:
   tags:
-    - Export Schedules
+    - Data Export Schedules
   summary: Modify an export schedule
   description: |
     Modify an existing export schedule
@@ -59,7 +59,7 @@ put:
         $ref: "#/definitions/ExportSchedule"
 delete:
   tags:
-    - Export Schedules
+    - Data Export Schedules
   summary: Delete an export schedule
   description: |
     Delete an existing export schedule

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -62,10 +62,10 @@ tags:
   - name: Reports
     description: |
       Retrieve summary information about your customers, subscriptions, transactions, and more.
-  - name: Exports
+  - name: Data Exports
     description: |
       Data exports.
-  - name: Export Schedules
+  - name: Data Export Schedules
     description: |
       Schedule recurring data exports.
 ################################################################################


### PR DESCRIPTION
Remove some lingering references to `Exports` section (it has now been renamed to Data Exports).