### PR TITLE
Remove leading slashes from fields names in fields list and filters

### DIFF
--- a/spec/components/schemas/DataExport.yaml
+++ b/spec/components/schemas/DataExport.yaml
@@ -63,8 +63,8 @@ properties:
         example: 'today'
       field:
         type: string
-        description: The field to apply date range to. Defaults to /processedTime for Transactions, /createdTime for Customers and Subscriptions.
-        example: '/processedTime'
+        description: The field to apply date range to. Defaults to `processedTime` for Transactions, `createdTime` for Customers and Subscriptions.
+        example: 'processedTime'
     required:
       - start
       - end

--- a/spec/components/schemas/DataExports/DataExport.yaml
+++ b/spec/components/schemas/DataExports/DataExport.yaml
@@ -58,11 +58,11 @@ properties:
     properties:
       start:
         type: string
-        description: Any valid datetime arguments including [relative datetime arguments](http://php.net/manual/en/datetime.resources.php).
+        description: Any valid datetime arguments including [relative datetime arguments](http://php.net/manual/en/datetime.formats.php).
         example: 'yesterday'
       end:
         type: string
-        description: Any valid datetime arguments including [relative datetime arguments](http://php.net/manual/en/datetime.resources.php).
+        description: Any valid datetime arguments including [relative datetime arguments](http://php.net/manual/en/datetime.formats.php).
         example: 'today'
       field:
         type: string

--- a/spec/components/schemas/DataExports/DataExport.yaml
+++ b/spec/components/schemas/DataExports/DataExport.yaml
@@ -1,4 +1,6 @@
 type: object
+discriminator:
+  propertyName: resource
 required:
   - name
   - format
@@ -55,16 +57,15 @@ properties:
     properties:
       start:
         type: string
-        description: Any valid datetime arguments including [relative datetime arguments](http://php.net/manual/en/datetime.formats.php).
+        description: Any valid datetime arguments including [relative datetime arguments](http://php.net/manual/en/datetime.resources.php).
         example: 'yesterday'
       end:
         type: string
-        description: Any valid datetime arguments including [relative datetime arguments](http://php.net/manual/en/datetime.formats.php).
+        description: Any valid datetime arguments including [relative datetime arguments](http://php.net/manual/en/datetime.resources.php).
         example: 'today'
       field:
         type: string
-        description: The field to apply date range to. Defaults to `processedTime` for Transactions, `createdTime` for Customers and Subscriptions.
-        example: 'processedTime'
+        description: The field to apply date range to.
     required:
       - start
       - end

--- a/spec/components/schemas/DataExports/resources/customers.yaml
+++ b/spec/components/schemas/DataExports/resources/customers.yaml
@@ -7,5 +7,6 @@ allOf:
         type: object
         properties:
           field:
+            type: string
             default: 'createdTime'
             example: 'createdTime'

--- a/spec/components/schemas/DataExports/resources/customers.yaml
+++ b/spec/components/schemas/DataExports/resources/customers.yaml
@@ -1,0 +1,11 @@
+description: Customers resource type to export
+allOf:
+  - $ref: "#/components/schemas/DataExport"
+  - type: "object"
+    properties:
+      dateRange:
+        type: object
+        properties:
+          field:
+            default: 'createdTime'
+            example: 'createdTime'

--- a/spec/components/schemas/DataExports/resources/subscriptions.yaml
+++ b/spec/components/schemas/DataExports/resources/subscriptions.yaml
@@ -7,5 +7,6 @@ allOf:
         type: object
         properties:
           field:
+            type: string
             default: 'createdTime'
             example: 'createdTime'

--- a/spec/components/schemas/DataExports/resources/subscriptions.yaml
+++ b/spec/components/schemas/DataExports/resources/subscriptions.yaml
@@ -1,0 +1,11 @@
+description: Subscriptions resource type to export
+allOf:
+  - $ref: "#/components/schemas/DataExport"
+  - type: "object"
+    properties:
+      dateRange:
+        type: object
+        properties:
+          field:
+            default: 'createdTime'
+            example: 'createdTime'

--- a/spec/components/schemas/DataExports/resources/transactions.yaml
+++ b/spec/components/schemas/DataExports/resources/transactions.yaml
@@ -7,5 +7,6 @@ allOf:
         type: object
         properties:
           field:
+            type: string
             default: 'processedTime'
             example: 'processedTime'

--- a/spec/components/schemas/DataExports/resources/transactions.yaml
+++ b/spec/components/schemas/DataExports/resources/transactions.yaml
@@ -1,0 +1,11 @@
+description: Transactions resource type to export
+allOf:
+  - $ref: "#/components/schemas/DataExport"
+  - type: "object"
+    properties:
+      dateRange:
+        type: object
+        properties:
+          field:
+            default: 'processedTime'
+            example: 'processedTime'


### PR DESCRIPTION
Currently data export request supports fields, filters and date range field without leading slashes 