### PR TITLE
Fix metrics parameter name

### DIFF
--- a/openapi/components/schemas/DashboardResponse.yaml
+++ b/openapi/components/schemas/DashboardResponse.yaml
@@ -2,7 +2,7 @@ type: array
 items:
   type: object
   properties:
-    metric:
+    metrics:
       type: string
       description: Metric type
       enum:


### PR DESCRIPTION
Rename `metric` parameter to proper `metrics` name.